### PR TITLE
cargo print host

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*]
+tab_width = 4
+
+[.*]
+tab_width = 4

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,6 +1,9 @@
+max_width = 150
+version = "Two"
+use_small_heuristics = "Max"
 hard_tabs = true
 imports_layout = "Horizontal"
-merge_imports = true
+imports_granularity = "Crate"
 fn_args_layout = "Compressed"
 use_field_init_shorthand = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ azure-devops = { project = "alecmocatta/cargo-print", pipeline = "tests", build 
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-cargo_metadata = "0.10"
+cargo_metadata = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-print"
-version = "0.1.4"
+version = "0.1.5"
 license = "MIT OR Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = []

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ cargo print package
 # prints the name of the package in the current directory
 cargo print directory <package-name>
 # prints the directory of the specified package
+cargo print host
+# prints rustc's host triple
 ```
 
 ## License

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
     endpoint: alecmocatta
     default:
       rust_toolchain: stable nightly
-      rust_lint_toolchain: nightly-2020-07-09
+      rust_lint_toolchain: nightly-2021-08-01
       rust_flags: ''
       rust_features: ''
       rust_target_check: ''
@@ -29,4 +29,4 @@ jobs:
         rust_target_run: 'x86_64-apple-darwin'
       linux:
         imageName: 'ubuntu-latest'
-        rust_target_run: 'x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl'
+        rust_target_run: 'x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-unknown-linux-musl'

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,10 @@
+use std::env::var;
+
+fn main() {
+	println!("cargo:rerun-if-changed=build.rs");
+
+	write("HOST", &var("HOST").unwrap());
+}
+fn write(key: &str, value: &str) {
+	println!("cargo:rustc-env={}={}", key, value);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@
 //! <a href="https://crates.io/crates/cargo-print">📦&nbsp;&nbsp;Crates.io</a>&nbsp;&nbsp;│&nbsp;&nbsp;<a href="https://github.com/alecmocatta/cargo-print">📑&nbsp;&nbsp;GitHub</a>&nbsp;&nbsp;│&nbsp;&nbsp;<a href="https://constellation.zulipchat.com/#narrow/stream/213236-subprojects">💬&nbsp;&nbsp;Chat</a>
 //! </strong></p>
 
-#![doc(html_root_url = "https://docs.rs/cargo-print/0.1.4")]
+#![doc(html_root_url = "https://docs.rs/cargo-print/0.1.5")]
 #![warn(
 	missing_copy_implementations,
 	missing_debug_implementations,

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,9 @@ fn main() {
 		Some("publish") => print_publish(args),
 		Some("package") => print_package(args),
 		Some("directory") => print_directory(args),
+		Some("host") => print_host(args),
 		_ => {
-			eprintln!("USAGE:\n    cargo print examples [--no-default-features] [--features <FEATURES>...] [--all-features]\n    cargo print publish\n    cargo print package\n    cargo print directory <package-name>");
+			eprintln!("USAGE:\n    cargo print examples [--no-default-features] [--features <FEATURES>...] [--all-features]\n    cargo print publish\n    cargo print package\n    cargo print directory <package-name>\n    cargo print host");
 			process::exit(1);
 		}
 	}
@@ -57,7 +58,7 @@ fn print_directory(mut args: impl Iterator<Item = String>) {
 	let package = package.into_iter().next().unwrap();
 	let mut manifest_path = package.manifest_path;
 	let _ = manifest_path.pop();
-	println!("{}", manifest_path.display());
+	println!("{}", manifest_path);
 }
 
 fn print_package(mut args: impl Iterator<Item = String>) {
@@ -258,4 +259,12 @@ fn print_examples(mut args: impl Iterator<Item = String>) {
 	for example in examples {
 		println!("{}", example);
 	}
+}
+
+fn print_host(mut args: impl Iterator<Item = String>) {
+	if args.next().is_some() {
+		eprintln!("USAGE:\n    cargo print host");
+		process::exit(1);
+	}
+	println!("{}", env!("HOST"));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@
 	unused_results,
 	clippy::pedantic
 )] // from https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md
-#![allow(clippy::if_not_else, clippy::too_many_lines)]
+#![allow(clippy::if_not_else, clippy::too_many_lines, clippy::let_underscore_drop)]
 
 use cargo_metadata::{CargoOpt, MetadataCommand};
 use std::{
@@ -32,7 +32,9 @@ fn main() {
 		Some("directory") => print_directory(args),
 		Some("host") => print_host(args),
 		_ => {
-			eprintln!("USAGE:\n    cargo print examples [--no-default-features] [--features <FEATURES>...] [--all-features]\n    cargo print publish\n    cargo print package\n    cargo print directory <package-name>\n    cargo print host");
+			eprintln!(
+				"USAGE:\n    cargo print examples [--no-default-features] [--features <FEATURES>...] [--all-features]\n    cargo print publish\n    cargo print package\n    cargo print directory <package-name>\n    cargo print host"
+			);
 			process::exit(1);
 		}
 	}
@@ -46,11 +48,7 @@ fn print_directory(mut args: impl Iterator<Item = String>) {
 		process::exit(1);
 	};
 	let metadata = MetadataCommand::new().exec().unwrap();
-	let package = metadata
-		.packages
-		.into_iter()
-		.filter(|package| package.name == package_name)
-		.collect::<Vec<_>>();
+	let package = metadata.packages.into_iter().filter(|package| package.name == package_name).collect::<Vec<_>>();
 	assert!(package.len() <= 1);
 	if package.is_empty() {
 		panic!("package {} not found", package_name);
@@ -69,11 +67,7 @@ fn print_package(mut args: impl Iterator<Item = String>) {
 	let current_dir = env::current_dir().unwrap();
 	let current_manifest = current_dir.join("Cargo.toml");
 	let metadata = MetadataCommand::new().exec().unwrap();
-	let package = metadata
-		.packages
-		.into_iter()
-		.filter(|package| package.manifest_path == current_manifest)
-		.collect::<Vec<_>>();
+	let package = metadata.packages.into_iter().filter(|package| package.manifest_path == current_manifest).collect::<Vec<_>>();
 	if package.len() > 1 {
 		panic!("We seem to be in > 1 package {:?}", package);
 	}
@@ -90,20 +84,11 @@ fn print_publish(mut args: impl Iterator<Item = String>) {
 		process::exit(1);
 	}
 	let metadata = MetadataCommand::new().exec().unwrap();
-	let members = metadata
-		.workspace_members
-		.into_iter()
-		.collect::<HashSet<_>>();
+	let members = metadata.workspace_members.into_iter().collect::<HashSet<_>>();
 	let members = metadata
 		.packages
 		.into_iter()
-		.filter_map(|package| {
-			if members.contains(&package.id) {
-				Some((package.name.clone(), package))
-			} else {
-				None
-			}
-		})
+		.filter_map(|package| if members.contains(&package.id) { Some((package.name.clone(), package)) } else { None })
 		.collect::<HashMap<_, _>>();
 	let mut members: HashMap<String, HashSet<String>> = members
 		.iter()
@@ -113,13 +98,7 @@ fn print_publish(mut args: impl Iterator<Item = String>) {
 				package
 					.dependencies
 					.iter()
-					.filter_map(|dep| {
-						if members.contains_key(&dep.name) {
-							Some(dep.name.clone())
-						} else {
-							None
-						}
-					})
+					.filter_map(|dep| if members.contains_key(&dep.name) { Some(dep.name.clone()) } else { None })
 					.collect::<HashSet<String>>(),
 			)
 		})
@@ -127,19 +106,11 @@ fn print_publish(mut args: impl Iterator<Item = String>) {
 	let mut dependents: HashMap<String, HashSet<String>> = HashMap::new();
 	for (package, dependencies) in &members {
 		for dependency in dependencies {
-			let _ = dependents
-				.entry(dependency.to_owned())
-				.or_insert_with(HashSet::new)
-				.insert(package.to_owned());
+			let _ = dependents.entry(dependency.clone()).or_insert_with(HashSet::new).insert(package.clone());
 		}
 	}
 	while !members.is_empty() {
-		let publish = members
-			.iter()
-			.find(|(_member, dependencies)| dependencies.is_empty())
-			.expect("circular dependencies")
-			.0
-			.clone();
+		let publish = members.iter().find(|(_member, dependencies)| dependencies.is_empty()).expect("circular dependencies").0.clone();
 		println!("{}", publish);
 		let _ = members.remove(&publish).unwrap();
 		for dependent in dependents.get(&publish).unwrap_or(&HashSet::new()) {
@@ -162,7 +133,7 @@ fn print_examples(mut args: impl Iterator<Item = String>) {
 						let _ = opt_features.insert(feature.to_owned());
 					}
 				} else {
-					error = true
+					error = true;
 				}
 			}
 			"--all-features" => opt_all_features = true,
@@ -180,18 +151,12 @@ fn print_examples(mut args: impl Iterator<Item = String>) {
 	if opt_no_default_features {
 		let _ = metadata.features(CargoOpt::NoDefaultFeatures);
 	}
-	let _ = metadata.features(CargoOpt::SomeFeatures(
-		opt_features.iter().cloned().collect(),
-	));
+	let _ = metadata.features(CargoOpt::SomeFeatures(opt_features.iter().cloned().collect()));
 	if opt_all_features {
 		let _ = metadata.features(CargoOpt::AllFeatures);
 	}
 	let metadata = metadata.exec().unwrap();
-	let package = metadata
-		.packages
-		.into_iter()
-		.filter(|package| package.manifest_path == current_manifest)
-		.collect::<Vec<_>>();
+	let package = metadata.packages.into_iter().filter(|package| package.manifest_path == current_manifest).collect::<Vec<_>>();
 	if package.len() > 1 {
 		panic!("We seem to be in > 1 package {:?}", package);
 	}
@@ -202,13 +167,7 @@ fn print_examples(mut args: impl Iterator<Item = String>) {
 	let features = package
 		.dependencies
 		.into_iter()
-		.filter_map(|dep| {
-			if dep.optional {
-				Some((dep.rename.unwrap_or(dep.name), Vec::new()))
-			} else {
-				None
-			}
-		})
+		.filter_map(|dep| if dep.optional { Some((dep.rename.unwrap_or(dep.name), Vec::new())) } else { None })
 		.chain(package.features.into_iter())
 		.collect::<HashMap<String, Vec<String>>>();
 	let features_set = features.keys().cloned().collect::<HashSet<_>>();
@@ -226,14 +185,11 @@ fn print_examples(mut args: impl Iterator<Item = String>) {
 	} else {
 		enabled_features = features.iter().map(|(k, _)| k.clone()).collect();
 	}
-	let mut features_stack = enabled_features
-		.clone()
-		.into_iter()
-		.collect::<VecDeque<_>>();
+	let mut features_stack = enabled_features.clone().into_iter().collect::<VecDeque<_>>();
 	while let Some(feature) = features_stack.pop_front() {
 		for feature in features.get(&feature).unwrap_or(&Vec::new()).iter() {
 			if enabled_features.insert(feature.clone()) {
-				features_stack.push_back(feature.clone())
+				features_stack.push_back(feature.clone());
 			}
 		}
 	}
@@ -242,13 +198,7 @@ fn print_examples(mut args: impl Iterator<Item = String>) {
 		.into_iter()
 		.filter_map(|target| {
 			if target.kind.contains(&String::from("example"))
-				&& target
-					.required_features
-					.iter()
-					.cloned()
-					.collect::<HashSet<_>>()
-					.difference(&enabled_features)
-					.count() == 0
+				&& target.required_features.iter().cloned().collect::<HashSet<_>>().difference(&enabled_features).count() == 0
 			{
 				Some(target.name)
 			} else {


### PR DESCRIPTION
TODO: to precisely get the host of the env `cargo`/`rustc` in the current directory (could be set by `build.target` in `.cargo/config`) we have to create a fake project with a build.rs, `cargo run`, print the host, and report that (at least that's the only reliable way I'm aware of?!). But that's OTT for now.

Release v0.1.5